### PR TITLE
Improving connection management in nodekeeper

### DIFF
--- a/keeper/nodekeeper.go
+++ b/keeper/nodekeeper.go
@@ -77,3 +77,15 @@ func (nk *NodeKeeper) GetConnection(node *diztl.Node) (pb.DiztlServiceClient, er
 func (nk *NodeKeeper) Disconnect(node *diztl.Node) bool {
 	return nk.invalidateIfExists(node)
 }
+
+// Close : Clears the resources held by this nodekeeper, making it unusable for further operations.
+func (nk *NodeKeeper) Close() {
+	for node, conn := range nk.connections {
+		err := conn.Close()
+		if err != nil {
+			log.Printf("Error while closing connection to %s: %v", node, err)
+		} else {
+			log.Printf("Closed connection to %s\n", node)
+		}
+	}
+}


### PR DESCRIPTION
- Nodekeeper should cache `*grpc.ClientConn` instead of the client references as only the former facilitates closing of the resource.
- Adding the `Close()` method in nodekeeper which should be called in case of node/tracker shutdown. 